### PR TITLE
feat(community): 로그인 상태에 따른 버튼 렌더링 로직 처리

### DIFF
--- a/apps/community/src/app/page.tsx
+++ b/apps/community/src/app/page.tsx
@@ -19,12 +19,11 @@ import Image from "next/image";
 import Link from "next/link";
 
 import ContentItem from "../entities/landing/contentItem";
-import { getUserFromSupabase } from "../shared/supabase/action";
 import { SIGN_UP_PATHNAME } from "../shared/config/pathname";
+import { getIsAuthenticated } from "../features/auth/lib/check-auth";
 
 export default async function LandingPage() {
-  const user = await getUserFromSupabase();
-  const isAuthenticated = !!user;
+  const isAuthenticated = await getIsAuthenticated();
 
   return (
     <div className="flex min-h-screen flex-col">

--- a/apps/community/src/app/page.tsx
+++ b/apps/community/src/app/page.tsx
@@ -19,8 +19,13 @@ import Image from "next/image";
 import Link from "next/link";
 
 import ContentItem from "../entities/landing/contentItem";
+import { getUserFromSupabase } from "../shared/supabase/action";
+import { SIGN_UP_PATHNAME } from "../shared/config/pathname";
 
-export default function LandingPage() {
+export default async function LandingPage() {
+  const user = await getUserFromSupabase();
+  const isAuthenticated = !!user;
+
   return (
     <div className="flex min-h-screen flex-col">
       <main className="flex-1">
@@ -56,9 +61,13 @@ export default function LandingPage() {
             </div>
             들의 커뮤니티
           </div>
-          <div className="flex flex-col gap-4 sm:flex-row">
-            <Button size="xl">지금 가입하기</Button>
-          </div>
+          {!isAuthenticated && (
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <Button size="xl" asChild>
+                <Link href={SIGN_UP_PATHNAME}>지금 가입하기</Link>
+              </Button>
+            </div>
+          )}
         </section>
 
         <section className="flex w-full flex-col gap-8 bg-muted p-8 md:flex-row md:py-24">

--- a/apps/community/src/features/auth/lib/check-auth.ts
+++ b/apps/community/src/features/auth/lib/check-auth.ts
@@ -1,0 +1,6 @@
+import { getAuthSession } from "@/src/shared/supabase";
+
+export const getIsAuthenticated = async () => {
+  const user = await getAuthSession();
+  return !!user;
+};


### PR DESCRIPTION
### Issue
https://github.com/product-engineer-community/pec-monorepo/issues/11

### 작업 내용
- 로그인한 유저는 '지금 시작하기' 버튼이 렌더링되지 안도록 처리
- '지금 시작하기' 버튼에 라우팅 로직이 없어서 추가

- '지금 시작하기' 버튼이 없는게 제일 자연스러워 보이는데 피드백 부탁드려요!
- '지금 시작하기' 버튼 클릭 시 회원가입 페이지로 이동시키는데, 로그인 페이지로 이동시키는게 더 좋다고 생각하시면 피드백 부탁드립니다!

### Result
![image](https://github.com/user-attachments/assets/91a9c677-7701-4106-aa82-fc6c31ba3a5b)


close https://github.com/product-engineer-community/pec-monorepo/issues/11