### PR TITLE
fix(community): 태그에 한글을 입력시 중복으로 입력되는 문제를 수정합니다.

### DIFF
--- a/apps/community/src/app/layout.tsx
+++ b/apps/community/src/app/layout.tsx
@@ -26,7 +26,7 @@ export default function RootLayout({
       <body className="bg-background text-foreground">
         <Providers>
           <BaseLayout>{children}</BaseLayout>
-          <Toaster />
+          <Toaster position="top-center" />
         </Providers>
       </body>
     </html>

--- a/apps/community/src/widgets/PostForm/index.tsx
+++ b/apps/community/src/widgets/PostForm/index.tsx
@@ -70,10 +70,20 @@ export default function PostForm() {
   }, [state]);
 
   const handleAddTag = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter" && e.currentTarget.value.trim()) {
+    if (e.nativeEvent.isComposing) {
+      return;
+    }
+
+    const trimmedTag = e.currentTarget.value.trim();
+
+    if (e.key === "Enter" && trimmedTag) {
       e.preventDefault();
-      const newTag = e.currentTarget.value.trim();
-      setTags((prevTags) => Array.from(new Set([...prevTags, newTag])));
+      if (tags.includes(trimmedTag)) {
+        toast.error("이미 추가된 태그입니다.");
+        return;
+      }
+
+      setTags((prevTags) => [...prevTags, trimmedTag]);
       e.currentTarget.value = "";
     }
   };


### PR DESCRIPTION
# 주요 변경 사항
PR 제목보다 더 추가된 작업들이 있는데 간단한 것들이라 해당 PR에 같이 넣었습니다!

- 토스트 노출 위치를 상단의 중앙(top-center)으로 수정했어요.
- 기존에 글작성 페이지에서 한글을 입력하면 중복으로 입력되는 문제가 있어서 수정했어요.
  - 만약에 `리액트`를 입력하고 엔터를 치면, 태그에는 `리액트`, `트` 이렇게 2개가 추가됐었어요.
- 태그 작성시 기존에 존재하는 태그를 입력하면 input의 텍스트만 그대로 사라졌었는데, 사용자가 인지하기 어려울 것 같아서 토스트를 띄워주도록 수정했어요.

# 개발 결과(이미지, 영상)(optional)

(이미지나 영상을 첨부해주세요.)
