### PR TITLE
feat(community): 유저, 썸네일 디폴트 svg 추가 및 적용

### DIFF
--- a/apps/community/public/default-article-thumbnail.svg
+++ b/apps/community/public/default-article-thumbnail.svg
@@ -1,0 +1,7 @@
+<svg width="120" height="120" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="120" height="120" fill="#E5ECF6"/>
+  <rect x="46" y="44" width="28" height="32" rx="6" fill="#0D4486"/>
+  <rect x="52" y="52" width="16" height="4" rx="2" fill="#E5ECF6"/>
+  <rect x="52" y="60" width="16" height="4" rx="2" fill="#E5ECF6"/>
+  <rect x="52" y="68" width="10" height="4" rx="2" fill="#E5ECF6"/>
+</svg>

--- a/apps/community/public/default-avatar.svg
+++ b/apps/community/public/default-avatar.svg
@@ -1,0 +1,5 @@
+<svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="80" height="80" rx="20" fill="#E5ECF6"/>
+  <circle cx="40" cy="32" r="16" fill="#0D4486"/>
+  <ellipse cx="40" cy="60" rx="20" ry="12" fill="#0D4486" fill-opacity="0.3"/>
+</svg>

--- a/apps/community/src/app/community/articles/page.tsx
+++ b/apps/community/src/app/community/articles/page.tsx
@@ -43,12 +43,12 @@ export default async function ArticlesPage() {
       excerpt: article.content || "아티클 요약이 없습니다.",
       author: {
         name: article.author?.username || "익명",
-        avatar: article.author?.avatar_url || "/placeholder.svg",
+        avatar: article.author?.avatar_url || "/default-avatar.svg",
       },
       publishedAt: new Date(article.created_at).toLocaleDateString("ko-KR"),
       readingTime: "8 min read",
       tags: article.tags || ["Product Engineer"],
-      coverImage: article.thumbnail_url || "/placeholder.svg",
+      coverImage: article.thumbnail_url || "/default-article-thumbnail.svg",
       category: article.category || "기타",
     };
   });


### PR DESCRIPTION
# 주요 변경 사항
* 유저 이미지, 아티클 썸네일 이미지가 없을 때 깨지길래, 각각의 svg를 제작하고 추가합니다.
* 모두 구분없이 `/placeholder.svg`로 내려오게 처리가 되어있어, 아티클, 유저를 각각 구분합니다.
(간단히 요약 해주세요.)

# 개발 결과(이미지, 영상)(optional)
![image](https://github.com/user-attachments/assets/cb5d3f6f-40cd-4c91-a3bd-738380eda0e5)

저희 서비스 프라이머리 컬러 맞게 임의로 만들었어요!
제가 디자인 감각은 영 없어서 ㅋㅋㅋ.. 피드백 환영입니다!
(이미지나 영상을 첨부해주세요.)
