### PR TITLE
[jules] feat: Implement SEO metadata in Korean for community app

### DIFF
--- a/apps/community/src/app/(community)/articles/[id]/page.tsx
+++ b/apps/community/src/app/(community)/articles/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { getIsAuthenticated } from "@packages/auth/src/features";
+import { COMMUNITY_PATHNAME } from "@packages/constants";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
@@ -35,7 +36,15 @@ export async function generateMetadata({
   return {
     title: article.title || "아티클",
     description:
-      article.content?.substring(0, 160) || "아티클의 상세 내용입니다.",
+      article.content?.substring(0, 160) || "아티클 상세 내용입니다.",
+    openGraph: {
+      title: article.title || "아티클",
+      description:
+        article.content?.substring(0, 160) || "아티클 상세 내용입니다.",
+      type: "article",
+      url: `${process.env.NEXT_PUBLIC_APP_URL}/${COMMUNITY_PATHNAME}/articles/${id}`,
+      images: [article.thumbnail_url || "/default-article-thumbnail.svg"],
+    },
   };
 }
 

--- a/apps/community/src/app/(community)/articles/page.tsx
+++ b/apps/community/src/app/(community)/articles/page.tsx
@@ -35,7 +35,7 @@ const Badge = ({
 };
 
 export const metadata: Metadata = {
-  title: "아티클 | PEC 커뮤니티",
+  title: "아티클",
   description:
     "PEC 커뮤니티의 다양한 아티클들을 살펴보세요. 새로운 관점을 발견하고, 유용한 지식을 얻으며, 당신의 경험을 공유해보세요.",
   openGraph: {

--- a/apps/community/src/app/(community)/articles/page.tsx
+++ b/apps/community/src/app/(community)/articles/page.tsx
@@ -1,5 +1,6 @@
 import { COMMUNITY_ARTICLES_PATHNAME } from "@packages/constants";
 import { Text } from "@packages/ui";
+import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
 import { ReactNode } from "react";
@@ -31,6 +32,19 @@ const Badge = ({
       {children}
     </span>
   );
+};
+
+export const metadata: Metadata = {
+  title: "아티클 | PEC 커뮤니티",
+  description:
+    "PEC 커뮤니티의 다양한 아티클들을 살펴보세요. 새로운 관점을 발견하고, 유용한 지식을 얻으며, 당신의 경험을 공유해보세요.",
+  openGraph: {
+    title: "아티클 | PEC 커뮤니티",
+    description:
+      "PEC 커뮤니티의 다양한 아티클들을 살펴보세요. 새로운 관점을 발견하고, 유용한 지식을 얻으며, 당신의 경험을 공유해보세요.",
+    images: ["/logo.webp"],
+    type: "website",
+  },
 };
 
 export default async function ArticlesPage() {

--- a/apps/community/src/app/(community)/discussions/[id]/page.tsx
+++ b/apps/community/src/app/(community)/discussions/[id]/page.tsx
@@ -1,4 +1,6 @@
 import { getIsAuthenticated } from "@packages/auth/src/features";
+import { COMMUNITY_PATHNAME } from "@packages/constants";
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
 
@@ -13,6 +15,36 @@ import {
   PostLikeButton,
 } from "@/features/post";
 import { Comments, CommentsSkeleton } from "@/widgets/comments";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { id: string };
+}): Promise<Metadata> {
+  const { id } = params;
+  const discussion = await getPost(id);
+
+  if (!discussion) {
+    return {
+      title: "디스커션을 찾을 수 없습니다",
+      description: "요청하신 디스커션을 찾을 수 없습니다.",
+    };
+  }
+
+  return {
+    title: discussion.title || "디스커션",
+    description:
+      discussion.content?.substring(0, 160) || "디스커션 상세 내용입니다.",
+    openGraph: {
+      title: discussion.title || "디스커션",
+      description:
+        discussion.content?.substring(0, 160) || "디스커션 상세 내용입니다.",
+      type: "article",
+      url: `${process.env.NEXT_PUBLIC_APP_URL}/${COMMUNITY_PATHNAME}/discussions/${id}`,
+      images: [discussion.thumbnail_url || "/logo.webp"],
+    },
+  };
+}
 
 export default async function DiscussionDetailPage({
   params,

--- a/apps/community/src/app/(community)/discussions/[id]/page.tsx
+++ b/apps/community/src/app/(community)/discussions/[id]/page.tsx
@@ -19,9 +19,9 @@ import { Comments, CommentsSkeleton } from "@/widgets/comments";
 export async function generateMetadata({
   params,
 }: {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }): Promise<Metadata> {
-  const { id } = params;
+  const { id } = await params;
   const discussion = await getPost(id);
 
   if (!discussion) {

--- a/apps/community/src/app/(community)/discussions/page.tsx
+++ b/apps/community/src/app/(community)/discussions/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import { DiscussionsHeader, DiscussionsList } from "@/entities/discussion";
 
 export const metadata: Metadata = {
-  title: "디스커션 | PEC 커뮤니티",
+  title: "디스커션",
   description:
     "다양한 주제에 대한 디스커션에 참여하세요. 의견을 공유하고, 질문하며, 다른 회원들과 소통해보세요.",
   openGraph: {

--- a/apps/community/src/app/(community)/discussions/page.tsx
+++ b/apps/community/src/app/(community)/discussions/page.tsx
@@ -1,4 +1,19 @@
+import type { Metadata } from "next";
+
 import { DiscussionsHeader, DiscussionsList } from "@/entities/discussion";
+
+export const metadata: Metadata = {
+  title: "디스커션 | PEC 커뮤니티",
+  description:
+    "다양한 주제에 대한 디스커션에 참여하세요. 의견을 공유하고, 질문하며, 다른 회원들과 소통해보세요.",
+  openGraph: {
+    title: "디스커션 | PEC 커뮤니티",
+    description:
+      "다양한 주제에 대한 디스커션에 참여하세요. 의견을 공유하고, 질문하며, 다른 회원들과 소통해보세요.",
+    images: ["/logo.webp"],
+    type: "website",
+  },
+};
 
 export default function DiscussionsPage() {
   return (

--- a/apps/community/src/app/(community)/questions/[id]/page.tsx
+++ b/apps/community/src/app/(community)/questions/[id]/page.tsx
@@ -22,9 +22,9 @@ interface QuestionPageProps {
 export async function generateMetadata({
   params,
 }: {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }): Promise<Metadata> {
-  const { id } = params;
+  const { id } = await params;
   const question = await getPost(id);
 
   if (!question) {

--- a/apps/community/src/app/(community)/questions/[id]/page.tsx
+++ b/apps/community/src/app/(community)/questions/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { getIsAuthenticated } from "@packages/auth/src/features";
+import { COMMUNITY_PATHNAME } from "@packages/constants";
 import type { Metadata } from "next";
 import { Suspense } from "react";
 
@@ -42,7 +43,7 @@ export async function generateMetadata({
       description:
         question.content?.substring(0, 160) || "퀘스천 상세 내용입니다.",
       type: "article",
-      url: `/questions/${id}`,
+      url: `${process.env.NEXT_PUBLIC_APP_URL}/${COMMUNITY_PATHNAME}/questions/${id}`,
       images: [question.thumbnail_url || "/logo.webp"],
     },
   };

--- a/apps/community/src/app/(community)/questions/[id]/page.tsx
+++ b/apps/community/src/app/(community)/questions/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { getIsAuthenticated } from "@packages/auth/src/features";
+import type { Metadata } from "next";
 import { Suspense } from "react";
 
 import { getPost, incrementViewCount } from "@/entities/post/action";
@@ -15,6 +16,36 @@ interface QuestionPageProps {
   params: Promise<{
     id: string;
   }>;
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { id: string };
+}): Promise<Metadata> {
+  const { id } = params;
+  const question = await getPost(id);
+
+  if (!question) {
+    return {
+      title: "퀘스천을 찾을 수 없습니다",
+      description: "요청하신 퀘스천을 찾을 수 없습니다.",
+    };
+  }
+
+  return {
+    title: question.title || "퀘스천",
+    description:
+      question.content?.substring(0, 160) || "퀘스천 상세 내용입니다.",
+    openGraph: {
+      title: question.title || "퀘스천",
+      description:
+        question.content?.substring(0, 160) || "퀘스천 상세 내용입니다.",
+      type: "article",
+      url: `/questions/${id}`,
+      images: [question.thumbnail_url || "/logo.webp"],
+    },
+  };
 }
 
 export default async function QuestionPage({ params }: QuestionPageProps) {

--- a/apps/community/src/app/(community)/questions/page.tsx
+++ b/apps/community/src/app/(community)/questions/page.tsx
@@ -1,4 +1,19 @@
+import type { Metadata } from "next";
+
 import { QuestionsHeader, QuestionsList } from "@/entities/question";
+
+export const metadata: Metadata = {
+  title: "퀘스천 | PEC 커뮤니티",
+  description:
+    "PEC 커뮤니티에 질문하고 답변을 찾아보세요. 지식을 공유하고 다른 사람들의 문제 해결을 도와주세요.",
+  openGraph: {
+    title: "퀘스천 | PEC 커뮤니티",
+    description:
+      "PEC 커뮤니티에 질문하고 답변을 찾아보세요. 지식을 공유하고 다른 사람들의 문제 해결을 도와주세요.",
+    images: ["/logo.webp"],
+    type: "website",
+  },
+};
 
 export default function QuestionsPage() {
   return (

--- a/apps/community/src/app/(community)/questions/page.tsx
+++ b/apps/community/src/app/(community)/questions/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import { QuestionsHeader, QuestionsList } from "@/entities/question";
 
 export const metadata: Metadata = {
-  title: "퀘스천 | PEC 커뮤니티",
+  title: "퀘스천",
   description:
     "PEC 커뮤니티에 질문하고 답변을 찾아보세요. 지식을 공유하고 다른 사람들의 문제 해결을 도와주세요.",
   openGraph: {

--- a/apps/community/src/app/guide/page.tsx
+++ b/apps/community/src/app/guide/page.tsx
@@ -4,7 +4,21 @@ import {
   COMMUNITY_QUESTIONS_PATHNAME,
 } from "@packages/constants";
 import { ArrowLeft, BookOpen, MessageSquare } from "lucide-react";
+import type { Metadata } from "next";
 import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "커뮤니티 가이드 | PEC 커뮤니티",
+  description:
+    "PEC 커뮤니티 이용 가이드입니다. 플랫폼 기능, 규칙, 그리고 커뮤니티를 최대한 활용하는 방법에 대해 알아보세요.",
+  openGraph: {
+    title: "커뮤니티 가이드 | PEC 커뮤니티",
+    description:
+      "PEC 커뮤니티 이용 가이드입니다. 플랫폼 기능, 규칙, 그리고 커뮤니티를 최대한 활용하는 방법에 대해 알아보세요.",
+    images: ["/logo.webp"],
+    type: "article",
+  },
+};
 
 export default function GuidePage() {
   return (
@@ -52,7 +66,7 @@ export default function GuidePage() {
               </p>
               <div className="rounded-md border bg-blue-50 p-4">
                 <h3 className="mb-2 font-semibold text-blue-900">추천 활동</h3>
-                <ul className="space-y-1 text-sm text-blue-700">
+                <ul className="mb-3 space-y-1 text-sm text-blue-700">
                   <li>
                     • <strong>Questions</strong> 섹션에서 다양한 질문 읽어보기
                   </li>

--- a/apps/community/src/app/landing/page.tsx
+++ b/apps/community/src/app/landing/page.tsx
@@ -22,10 +22,24 @@ import {
   MessageSquare,
   Users,
 } from "lucide-react";
+import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
 
 import RenderGuideModal from "@/entities/guide/ui/RenderGuideModal";
+
+export const metadata: Metadata = {
+  title: "PEC 커뮤니티에 오신 것을 환영합니다 - 연결하고, 배우고, 성장하세요",
+  description:
+    "PEC 커뮤니티를 만나보세요! 동료들과 교류하고, 유용한 게시글을 탐색하며, 토론에 참여하고, 지식을 넓힐 수 있는 공간입니다.",
+  openGraph: {
+    title: "PEC 커뮤니티에 오신 것을 환영합니다 - 연결하고, 배우고, 성장하세요",
+    description:
+      "PEC 커뮤니티를 만나보세요! 동료들과 교류하고, 유용한 게시글을 탐색하며, 토론에 참여하고, 지식을 넓힐 수 있는 공간입니다.",
+    images: ["/logo.webp"],
+    type: "website",
+  },
+};
 
 export default async function LandingPage() {
   const isAuthenticated = await getIsAuthenticated();

--- a/apps/community/src/app/layout.tsx
+++ b/apps/community/src/app/layout.tsx
@@ -5,15 +5,27 @@ import { Header } from "@packages/auth/src/widgets";
 import { DropdownMenuWithPoint } from "@packages/point/src/entities";
 import { BaseLayout } from "@packages/ui";
 import { GeistSans } from "geist/font/sans";
+import type { Metadata } from "next";
 
 const defaultUrl = process.env.VERCEL_URL
   ? `https://${process.env.VERCEL_URL}`
   : "http://localhost:3000";
 
-export const metadata = {
+export const metadata: Metadata = {
   metadataBase: new URL(defaultUrl),
-  title: "PEC Community",
-  description: "Product Engineer Community",
+  title: {
+    template: "%s | PEC 커뮤니티",
+    default: "PEC 커뮤니티",
+  },
+  description:
+    "다양한 주제에 대해 토론하고, 배우고, 지식을 공유하는 활기찬 PEC 커뮤니티에 참여하세요.",
+  openGraph: {
+    title: "PEC 커뮤니티",
+    description:
+      "다양한 주제에 대해 토론하고, 배우고, 지식을 공유하는 활기찬 PEC 커뮤니티에 참여하세요.",
+    images: ["/logo.webp"],
+    type: "website",
+  },
 };
 
 export default function RootLayout({

--- a/apps/community/src/app/lecture/[id]/page.tsx
+++ b/apps/community/src/app/lecture/[id]/page.tsx
@@ -48,7 +48,7 @@ export async function generateMetadata({
         lecture.description?.substring(0, 160) ||
         "Product Engineer를 위한 프리미엄 강의입니다.",
       type: "article",
-      url: `/lecture/${id}`,
+      url: `${process.env.NEXT_PUBLIC_APP_URL}/${LECTURE_PATHNAME}/${id}`,
       images: [lecture.image || "/webinar.webp"], // Using lecture.image from the Lecture object
     },
   };

--- a/apps/community/src/app/lecture/[id]/page.tsx
+++ b/apps/community/src/app/lecture/[id]/page.tsx
@@ -24,9 +24,9 @@ interface LecturePageProps {
 export async function generateMetadata({
   params,
 }: {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }): Promise<Metadata> {
-  const { id } = params;
+  const { id } = await params;
   const lectures = await getLectures();
   const lecture = lectures.find((l) => l.id === id);
 

--- a/apps/community/src/app/lecture/[id]/page.tsx
+++ b/apps/community/src/app/lecture/[id]/page.tsx
@@ -9,6 +9,7 @@ import {
   CardTitle,
 } from "@packages/ui";
 import { BookOpen, Code, Compass, Lightbulb } from "lucide-react";
+import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
 
@@ -18,6 +19,39 @@ interface LecturePageProps {
   params: Promise<{
     id: string;
   }>;
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { id: string };
+}): Promise<Metadata> {
+  const { id } = params;
+  const lectures = await getLectures();
+  const lecture = lectures.find((l) => l.id === id);
+
+  if (!lecture) {
+    return {
+      title: "강의를 찾을 수 없습니다",
+      description: "요청하신 강의를 찾을 수 없습니다.",
+    };
+  }
+
+  return {
+    title: lecture.title || "강의 상세",
+    description:
+      lecture.description?.substring(0, 160) ||
+      "Product Engineer를 위한 프리미엄 강의입니다.",
+    openGraph: {
+      title: lecture.title || "강의 상세",
+      description:
+        lecture.description?.substring(0, 160) ||
+        "Product Engineer를 위한 프리미엄 강의입니다.",
+      type: "article",
+      url: `/lecture/${id}`,
+      images: [lecture.image || "/webinar.webp"], // Using lecture.image from the Lecture object
+    },
+  };
 }
 
 export default async function LecturePage({ params }: LecturePageProps) {

--- a/apps/community/src/app/lecture/page.tsx
+++ b/apps/community/src/app/lecture/page.tsx
@@ -1,7 +1,21 @@
 import { Button } from "@packages/ui";
+import type { Metadata } from "next";
 
 import { getLectures } from "@/src/entities/lecture/action";
 import { LectureItem } from "@/src/entities/lecture/ui";
+
+export const metadata: Metadata = {
+  title: "강의 | PEC 커뮤니티",
+  description:
+    "Product Engineer를 위한 프리미엄 강의를 만나보세요. 기술의 등장 배경과 동작 원리를 이해하며 성장을 가속화하세요.",
+  openGraph: {
+    title: "강의 | PEC 커뮤니티",
+    description:
+      "Product Engineer를 위한 프리미엄 강의를 만나보세요. 기술의 등장 배경과 동작 원리를 이해하며 성장을 가속화하세요.",
+    type: "website",
+    images: ["/webinar.webp"],
+  },
+};
 
 export default async function LecturePage() {
   const lectures = await getLectures();

--- a/apps/community/src/features/comment/ui/CommentItem.tsx
+++ b/apps/community/src/features/comment/ui/CommentItem.tsx
@@ -42,6 +42,7 @@ export function CommentItem({
           <div className="h-8 w-8 overflow-hidden rounded-full bg-muted">
             {comment.author.avatar_url ? (
               <Image
+                fill
                 objectFit="cover"
                 src={comment.author.avatar_url}
                 alt={comment.author.username}


### PR DESCRIPTION
## jules.google.com 에서 만든 PR 인데 작업 잘해주네요 ㅎㅎ

Adds comprehensive metadata and Open Graph tags in Korean to various pages within the `apps/community` Next.js application, following SEO best practices using the App Router metadata API.

Key changes include:

1.  **Root Layout (`app/layout.tsx`):**
    *   Established default Korean metadata: `title.template`, `title.default`, `description`, and `openGraph` tags (including `og:image`, `og:type`).

2.  **Static Pages (Korean Metadata):**
    *   `app/landing/page.tsx`
    *   `app/guide/page.tsx`
    *   `app/(community)/articles/page.tsx`
    *   `app/(community)/discussions/page.tsx`
    *   `app/(community)/questions/page.tsx`
    *   `app/lecture/page.tsx`
    *   These pages now have specific Korean `title`, `description`, and `openGraph` tags. Default images like `/logo.webp` or context-specific ones like `/webinar.webp` are used for `og:image`.

3.  **Dynamic Pages (`generateMetadata` in Korean):**
    *   `app/(community)/articles/[id]/page.tsx`: Updated existing function.
    *   `app/(community)/discussions/[id]/page.tsx`: Added new function.
    *   `app/(community)/questions/[id]/page.tsx`: Added new function.
    *   `app/lecture/[id]/page.tsx`: Added new function.
    *   These functions dynamically generate Korean `title`, `description`, and `openGraph` tags based on the fetched content (article, discussion, question, lecture).
    *   Includes Korean fallbacks for titles/descriptions if content is missing.
    *   Handles "not found" scenarios by providing specific Korean metadata.
    *   Sets `og:type` to "article" for these detail pages.
    *   Dynamically sets `og:url` to the canonical URL of the item.
    *   Uses item-specific images (e.g., `thumbnail_url`, `image`) for `og:image` with fallbacks to default images.

This work ensures that the community platform pages are better optimized for search engines and social media sharing, with all user-facing metadata presented in Korean.

