### PR TITLE
fix: 댓글, 답글 작성 완료 후 값이 에디터에 그대로 남아있는 현상 수정

### DIFF
--- a/apps/community/src/shared/components/InitializedMDXEditor.tsx
+++ b/apps/community/src/shared/components/InitializedMDXEditor.tsx
@@ -21,12 +21,9 @@ import {
   toolbarPlugin,
   UndoRedo,
 } from "@mdxeditor/editor";
-import type { ForwardedRef } from "react";
+import { useEffect, useRef } from "react";
 
-export default function InitializedMDXEditor({
-  editorRef,
-  ...props
-}: { editorRef: ForwardedRef<MDXEditorMethods> | null } & MDXEditorProps) {
+export default function InitializedMDXEditor({ ...props }: MDXEditorProps) {
   const imageUploadHandler = async (image: File) => {
     const formData = new FormData();
     formData.append("image", image);
@@ -39,6 +36,13 @@ export default function InitializedMDXEditor({
     const json = (await response.json()) as { url: string };
     return json.url;
   };
+
+  const internalRef = useRef<MDXEditorMethods>(null);
+  useEffect(() => {
+    if (internalRef.current) {
+      internalRef.current.setMarkdown(props.markdown);
+    }
+  }, [props.markdown]);
 
   return (
     <MDXEditor
@@ -77,7 +81,7 @@ export default function InitializedMDXEditor({
         }),
       ]}
       {...props}
-      ref={editorRef}
+      ref={internalRef}
     />
   );
 }

--- a/apps/community/src/shared/components/editor.tsx
+++ b/apps/community/src/shared/components/editor.tsx
@@ -19,8 +19,8 @@ const MDXViewerComponent = dynamic(
 
 // 다른 컴포넌트에서 사용할 forwardRef 컴포넌트
 const ForwardRefEditor = forwardRef<MDXEditorMethods, MDXEditorProps>(
-  (props, ref) => {
-    return <MDXEditorComponent editorRef={ref} {...props} />;
+  (props) => {
+    return <MDXEditorComponent {...props} />;
   },
 );
 
@@ -42,7 +42,6 @@ export function Editor({ content, onChange }: EditorProps) {
         markdown={content}
         onChange={onChange}
         placeholder="내용을 입력하세요"
-        editorRef={null}
       />
     </div>
   );


### PR DESCRIPTION
## 관련 이슈
아래처럼 써주시면, 자동으로 관련 Issue 가 Closed 처리되어요
(close #이슈번호)
close #103 

## 주요 변경 사항
* 에디터 외부에서 setContent('')을 통해서 실제 값은 초기화가 되었으나, 에디터 내부에선 값이 그대로 유지되고 있습니다.
* ref를 외부에서 전달받는 형태에서, 내부에서 관리하는 형태로 변경하였습니다.
* props.markdown (=content)가 변경되면 내부에서 useEffect 구문으로 처리해줍니다.
(간단히 요약 해주세요.)

## 개발 결과(이미지, 영상)(optional)
![image](https://github.com/user-attachments/assets/253f10df-0bc2-4431-9bb1-7c3b025861f9)

(이미지나 영상을 첨부해주세요.)
